### PR TITLE
adapt to newer pytorch versions

### DIFF
--- a/torch_utils/ops/conv2d_gradfix.py
+++ b/torch_utils/ops/conv2d_gradfix.py
@@ -5,6 +5,7 @@ arbitrarily high order gradients with zero performance penalty."""
 import warnings
 import contextlib
 import torch
+from distutils.version import LooseVersion
 
 # pylint: disable=redefined-builtin
 # pylint: disable=arguments-differ
@@ -43,7 +44,7 @@ def _should_use_custom_op(input):
         return False
     if input.device.type != 'cuda':
         return False
-    if any(torch.__version__.startswith(x) for x in ['1.7.', '1.8.', '1.9']):
+    if LooseVersion(torch.__version__) >= LooseVersion('1.7.0'):
         return True
     warnings.warn(f'conv2d_gradfix not supported on PyTorch {torch.__version__}. Falling back to torch.nn.functional.conv2d().')
     return False
@@ -105,12 +106,12 @@ def _conv2d_gradfix(transpose, weight_shape, stride, padding, output_padding, di
                 output = torch.nn.functional.conv2d(input=input, weight=weight, bias=bias, **common_kwargs)
             else: # transpose
                 output = torch.nn.functional.conv_transpose2d(input=input, weight=weight, bias=bias, output_padding=output_padding, **common_kwargs)
-            ctx.save_for_backward(input, weight)
+            ctx.save_for_backward(input, weight, bias)
             return output
 
         @staticmethod
         def backward(ctx, grad_output):
-            input, weight = ctx.saved_tensors
+            input, weight, bias = ctx.saved_tensors
             grad_input = None
             grad_weight = None
             grad_bias = None
@@ -121,7 +122,7 @@ def _conv2d_gradfix(transpose, weight_shape, stride, padding, output_padding, di
                 assert grad_input.shape == input.shape
 
             if ctx.needs_input_grad[1] and not weight_gradients_disabled:
-                grad_weight = Conv2dGradWeight.apply(grad_output, input)
+                grad_weight = Conv2dGradWeight.apply(grad_output, input, bias)
                 assert grad_weight.shape == weight_shape
 
             if ctx.needs_input_grad[2]:
@@ -132,10 +133,10 @@ def _conv2d_gradfix(transpose, weight_shape, stride, padding, output_padding, di
     # Gradient with respect to the weights.
     class Conv2dGradWeight(torch.autograd.Function):
         @staticmethod
-        def forward(ctx, grad_output, input):
-            op = torch._C._jit_get_operation('aten::cudnn_convolution_backward_weight' if not transpose else 'aten::cudnn_convolution_transpose_backward_weight')
-            flags = [torch.backends.cudnn.benchmark, torch.backends.cudnn.deterministic, torch.backends.cudnn.allow_tf32]
-            grad_weight = op(weight_shape, grad_output, input, padding, stride, dilation, groups, *flags)
+        def forward(ctx, grad_output, input, bias):
+            bias_shape = bias.shape if (bias is not None) else None
+            empty_weight = torch.empty(weight_shape, dtype=input.dtype, layout=input.layout, device=input.device)
+            grad_weight = torch.ops.aten.convolution_backward(grad_output, input, empty_weight, bias_sizes=bias_shape, stride=stride, padding=padding, dilation=dilation, transposed=transpose, output_padding=output_padding, groups=groups, output_mask=[0,1,0])[1]
             assert grad_weight.shape == weight_shape
             ctx.save_for_backward(grad_output, input)
             return grad_weight

--- a/torch_utils/ops/grid_sample_gradfix.py
+++ b/torch_utils/ops/grid_sample_gradfix.py
@@ -6,6 +6,7 @@ Only works on 2D images and assumes
 
 import warnings
 import torch
+from distutils.version import LooseVersion
 
 # pylint: disable=redefined-builtin
 # pylint: disable=arguments-differ
@@ -27,7 +28,7 @@ def grid_sample(input, grid):
 def _should_use_custom_op():
     if not enabled:
         return False
-    if any(torch.__version__.startswith(x) for x in ['1.7.', '1.8.', '1.9']):
+    if LooseVersion(torch.__version__) >= LooseVersion('1.7.0'):
         return True
     warnings.warn(f'grid_sample_gradfix not supported on PyTorch {torch.__version__}. Falling back to torch.nn.functional.grid_sample().')
     return False


### PR DESCRIPTION
When not using docker, the changes are needed for PyTorch versions > 1.7.

In addition `aten::cudnn_convolution_backward_weight` and `aten::cudnn_convolution_transpose_backward_weight` are deperacated at the beginning of this year, so adapted it to `torch.ops.aten.convolution_backward`